### PR TITLE
fix: send binary NATS payloads as WS binary frames, not text

### DIFF
--- a/cmd/nats-ws-gateway-and-server/main.go
+++ b/cmd/nats-ws-gateway-and-server/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gorilla/websocket"
 	natsserver "github.com/nats-io/nats-server/v2/server"
@@ -198,7 +199,14 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, topic string, nc *n
 
 	// Subscribe to NATS for messages to send to the WebSocket client
 	sub, err := nc.Subscribe(topic, func(m *nats.Msg) {
-		err := conn.WriteMessage(websocket.TextMessage, m.Data)
+		// Not all payloads carry a message-type hint, so infer text vs
+		// binary framing from the bytes: valid UTF-8 goes out as a text
+		// frame, anything else (e.g. gzip) goes out as a binary frame.
+		wsMessageType := websocket.TextMessage
+		if !utf8.Valid(m.Data) {
+			wsMessageType = websocket.BinaryMessage
+		}
+		err := conn.WriteMessage(wsMessageType, m.Data)
 		if err != nil {
 			slog.Warn("❌ Write to WS failed", "err", err, "client", r.RemoteAddr)
 		}


### PR DESCRIPTION
## Summary
- The NATS→WebSocket relay in `handleWebSocket` always wrote outgoing messages with `websocket.TextMessage`, regardless of the actual payload content.
- Per RFC 6455, WebSocket text frames must contain valid UTF-8. When a NATS message carries binary data (e.g. gzip-compressed payloads), sending it as a text frame causes spec-compliant clients — notably browsers — to UTF-8-decode it on receipt, replacing invalid byte sequences with U+FFFD and silently corrupting the payload, even though the server itself never altered the bytes it forwarded.
- This change inspects each payload with `utf8.Valid(m.Data)` before writing it to the socket: valid UTF-8 is sent as a text frame (unchanged behavior), anything else is sent as a binary frame. The bytes on the wire are identical either way — only the frame's opcode changes to match the content.

## Rationale
This is a targeted fix for a real correctness bug, not a redesign: NATS is payload-agnostic (any subject can carry either text or binary data), but the gateway was collapsing that distinction and unconditionally declaring everything text. UTF-8 sniffing was chosen over the alternative (explicit typing via NATS message headers) to keep the change minimal and avoid requiring publishers to opt in to new metadata — it's a heuristic rather than an authoritative signal, but it correctly handles the common cases (JSON/text vs. gzip/binary) with no protocol changes on the publish side.

## Test plan
- [x] `go build ./cmd/...` succeeds
- [ ] Manual verification: publish a gzip-compressed payload to a NATS subject and confirm a browser WebSocket client receives an unmangled `ArrayBuffer`/binary frame rather than a mangled text frame
- [ ] Manual verification: existing text/JSON traffic still round-trips as `TextMessage` frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AM8ZV8WTcsRWXKrMnp1G4q